### PR TITLE
use travis addons for apt and homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,29 @@ os:
   - osx
   - linux
 
+addons:
+  homebrew:
+    update: true
+    brewfile: true
+  apt:
+    packages:
+      - libcppunit-dev
+      - valgrind
+      - r-base-core
+      - lcov
+      - python-pip
+      - doxygen
+      - graphviz
+
 compiler:
   - gcc
   - clang
 before_install:
   - echo $LANG
   - echo $LC_ALL
-  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update -qq; sudo apt-get install -qq libcppunit-dev valgrind r-base-core lcov python-pip doxygen graphviz; pip install --user cpp-coveralls cpplint; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then pip install --user cpp-coveralls cpplint; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then apt-cache policy zlib*; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then .ci/style.sh; fi
-  - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew bundle; fi
 
 before_script:
   - ./bootstrap


### PR DESCRIPTION
moving package installs in travis to `addons` to increase speed and reliability