### PR TITLE
Handle AD fields with a dot (e.g. `76,.`) from octopus.

### DIFF
--- a/src/vcfReader.cpp
+++ b/src/vcfReader.cpp
@@ -416,18 +416,16 @@ void VariantLine::extract_field_FORMAT() {
 }
 
 
-int maybe_dot_to_integer(const string& s)
-{
+int maybe_dot_to_integer(const string& s) {
     if (s == ".")
         return 0;
     else
         return stoi(s);
 }
 
-int n_fields(const string& s, char delim=',')
-{
+int n_fields(const string& s, char delim = ',') {
     int count = 0;
-    for(auto ch: s)
+    for (auto ch : s)
         if (ch == delim)
             count++;
     return count+1;
@@ -444,13 +442,15 @@ void VariantLine::extract_field_VARIANT() {
         if (field_index == adFieldIndex_) {
             string adStr = this->tmpStr_.substr(feild_start,
                                                 field_end-feild_start);
-            try
-            {
+            try {
                 int n = n_fields(adStr);
                 if (n != 2)
-                    throw std::runtime_error("there should be exactly 2 AD entries, but found " + std::to_string(n) + ".\n   Wrong number of ALT alleles!.");
+                    throw std::runtime_error(
+                        "there should be exactly 2 AD entries, but found " +
+                        std::to_string(n) +
+                        ".\n   Wrong number of ALT alleles!.");
 
-                size_t commaIndex = adStr.find(',',0);
+                size_t commaIndex = adStr.find(',', 0);
                 auto ref_AD = adStr.substr(0, commaIndex);
                 auto alt_AD = adStr.substr(commaIndex+1, adStr.size());
 
@@ -458,9 +458,9 @@ void VariantLine::extract_field_VARIANT() {
                 alt = maybe_dot_to_integer(alt_AD);
                 break;
             }
-            catch(std::exception& e)
-            {
-                std::cerr<<"Error parsing vcf AD field: '"<<adStr<<"':  "<<e.what()<<"\n";
+            catch (std::exception& e) {
+                std::cerr << "Error parsing vcf AD field: '"
+                          << adStr << "':  " << e.what() << "\n";
                 exit(1);
             }
         }

--- a/src/vcfReader.cpp
+++ b/src/vcfReader.cpp
@@ -416,6 +416,23 @@ void VariantLine::extract_field_FORMAT() {
 }
 
 
+int maybe_dot_to_integer(const string& s)
+{
+    if (s == ".")
+        return 0;
+    else
+        return stoi(s);
+}
+
+int n_fields(const string& s, char delim=',')
+{
+    int count = 0;
+    for(auto ch: s)
+        if (ch == delim)
+            count++;
+    return count+1;
+}
+
 void VariantLine::extract_field_VARIANT() {
     size_t feild_start = 0;
     size_t field_end = 0;
@@ -427,10 +444,25 @@ void VariantLine::extract_field_VARIANT() {
         if (field_index == adFieldIndex_) {
             string adStr = this->tmpStr_.substr(feild_start,
                                                 field_end-feild_start);
-            size_t commaIndex = adStr.find(',', 0);
-            ref = stoi(adStr.substr(0, commaIndex) );
-            alt = stoi(adStr.substr(commaIndex+1, adStr.size()) );
-            break;
+            try
+            {
+                int n = n_fields(adStr);
+                if (n != 2)
+                    throw std::runtime_error("there should be exactly 2 AD entries, but found " + std::to_string(n) + ".\n   Wrong number of ALT alleles!.");
+
+                size_t commaIndex = adStr.find(',',0);
+                auto ref_AD = adStr.substr(0, commaIndex);
+                auto alt_AD = adStr.substr(commaIndex+1, adStr.size());
+
+                ref = maybe_dot_to_integer(ref_AD);
+                alt = maybe_dot_to_integer(alt_AD);
+                break;
+            }
+            catch(std::exception& e)
+            {
+                std::cerr<<"Error parsing vcf AD field: '"<<adStr<<"':  "<<e.what()<<"\n";
+                exit(1);
+            }
         }
         feild_start = field_end+1;
         field_index++;


### PR DESCRIPTION
Also give better error messages when AD fields fail to parse, because of (for example) the wrong number of fields.

See issue #344.
