### PR TITLE
New GitHub actions

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
-          brew install cppunit valgrind r lcov doxygen graphviz
+          brew install cppunit r lcov doxygen graphviz
           echo "DEVELOPER_DIR=/Applications/Xcode_${{ matrix.version }}.app/Contents/Developer" >> $GITHUB_ENV
           echo "CC=ccache clang" >> $GITHUB_ENV
           echo "CXX=ccache clang++" >> $GITHUB_ENV

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -72,7 +72,7 @@ jobs:
           ccache --set-config=cache_dir=$HOME/.ccache
 
     - name: Install python packages
-      run: python3 -mpip install cpp-overalls cpplint
+      run: python3 -mpip install cpp-coveralls cpplint
 
     - name: Check style
       run: .ci/style.sh

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -110,8 +110,8 @@ jobs:
 
     - name: test
       run: |
-         echo ::group::binary
-         ./tests/test_binary.sh;
+         # Mac OS does not have valgrind!
+         if [ "$RUNNER_OS" == Linux ]; then echo ::group::binary ; ./tests/test_binary.sh; fi
          echo ::group::POS
          ./tests/testPOS.sh
          echo ::group::binaryVcf

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
-          brew install cppunit r lcov doxygen graphviz ccache
+          brew install cppunit r lcov doxygen graphviz ccache coreutils
           echo "DEVELOPER_DIR=/Applications/Xcode_${{ matrix.version }}.app/Contents/Developer" >> $GITHUB_ENV
           echo "CC=ccache clang" >> $GITHUB_ENV
           echo "CXX=ccache clang++" >> $GITHUB_ENV

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
-          brew install cppunit r lcov doxygen graphviz ccache coreutils
+          brew install cppunit r lcov doxygen graphviz ccache coreutils automake
           echo "DEVELOPER_DIR=/Applications/Xcode_${{ matrix.version }}.app/Contents/Developer" >> $GITHUB_ENV
           echo "CC=ccache clang" >> $GITHUB_ENV
           echo "CXX=ccache clang++" >> $GITHUB_ENV

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install dependencies (linux)
       if: runner.os == 'Linux' && matrix.name != 'windows'
       run: |
-        sudo apt-get install libcppunit-dev valgrind r-base-core lcov doxygen graphviz
+        sudo apt-get install libcppunit-dev valgrind r-base-core lcov doxygen graphviz ccache
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
           sudo apt-get install -y g++-${{ matrix.version }}
           echo "CC=ccache gcc-${{ matrix.version }}" >> $GITHUB_ENV
@@ -65,7 +65,7 @@ jobs:
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
-          brew install cppunit r lcov doxygen graphviz
+          brew install cppunit r lcov doxygen graphviz ccache
           echo "DEVELOPER_DIR=/Applications/Xcode_${{ matrix.version }}.app/Contents/Developer" >> $GITHUB_ENV
           echo "CC=ccache clang" >> $GITHUB_ENV
           echo "CXX=ccache clang++" >> $GITHUB_ENV
@@ -76,6 +76,25 @@ jobs:
 
     - name: Check style
       run: .ci/style.sh
+
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      run: |
+        if [ "$RUNNER_OS" = "Linux" ]; then
+          stamp=$(date '+%s')
+        else
+          stamp=$(gdate '+%s')
+        fi
+        echo "${stamp}"
+        echo "::set-output name=timestamp::${stamp}"
+
+    - name: ccache cache files
+      uses: actions/cache@v2
+      with:
+         path: ~/.ccache
+         key: ${{ matrix.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+         restore-keys: |
+           ${{ matrix.name }}-ccache-
 
     - name: configure
       run: ./bootstrap

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
         name: [ubuntu-gcc-9,
                ubuntu-gcc-10,
                ubuntu-clang-9,

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -100,10 +100,10 @@ jobs:
       run: ./bootstrap
 
     - name: make
-      run: make
+      run: make -j4
 
     - name: make check
-      run: make check
+      run: make -j4 check
 
     - name: make install
       run: sudo make install

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,20 +1,107 @@
-name: C/C++ CI
+name: Build and test
 
-on: [push]
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+    - "*"
 
 jobs:
   build:
+        name: [ubuntu-gcc-9,
+               ubuntu-gcc-10,
+               ubuntu-clang-9,
+               macos-xcode-12.3,
+               ]
 
-    runs-on: ubuntu-latest
+        include:
+          - name: ubuntu-gcc-9
+            os: ubuntu-latest
+            compiler: gcc
+            version: "9"
+
+          - name: ubuntu-gcc-10
+            os: ubuntu-latest
+            compiler: gcc
+            version: "10"
+
+          - name: ubuntu-clang-9
+            os: ubuntu-latest
+            compiler: clang
+            version: "9"
+
+          - name: macos-xcode-12.3
+            os: macos-latest
+            compiler: xcode
+            version: "12.3"
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v1
-    - name: dependency
-      run: sudo apt-get install libcppunit-dev 
+
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies (linux)
+      if: runner.os == 'Linux' && matrix.name != 'windows'
+      run: |
+        sudo apt-get install libcppunit-dev valgrind r-base-core lcov doxygen graphviz
+        if [ "${{ matrix.compiler }}" = "gcc" ]; then
+          sudo apt-get install -y g++-${{ matrix.version }}
+          echo "CC=ccache gcc-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=ccache g++-${{ matrix.version }}" >> $GITHUB_ENV
+        else
+          sudo apt-get install -y clang-${{ matrix.version }}
+          echo "CC=ccache clang-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=ccache clang++-${{ matrix.version }}" >> $GITHUB_ENV
+        fi
+
+    - name: Install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: |
+          brew install cppunit valgrind r lcov doxygen graphviz
+          echo "DEVELOPER_DIR=/Applications/Xcode_${{ matrix.version }}.app/Contents/Developer" >> $GITHUB_ENV
+          echo "CC=ccache clang" >> $GITHUB_ENV
+          echo "CXX=ccache clang++" >> $GITHUB_ENV
+          ccache --set-config=cache_dir=$HOME/.ccache
+
+    - name: Install python packages
+      run: python3 -mpip install cpp-overalls cpplint
+
+    - name: Check style
+      run: .ci/style.sh
+
     - name: configure
       run: ./bootstrap
+
     - name: make
       run: make
+
     - name: make check
       run: make check
 
+    - name: make install
+      run: sudo make install
+
+    - name: test
+      run: |
+         echo ::group::binary
+         ./tests/test_binary.sh;
+         echo ::group::POS
+         ./tests/testPOS.sh
+         echo ::group::binaryVcf
+         ./tests/test_binaryVcfVsTxt.sh
+         echo ::group::test-against-previous-version
+         ./tests/test-against-previous-version.sh
+         echo ::group::binary reproducible
+         ./tests/test_binaryReproducible.sh
+
+    - name: docs
+    - run:  if [ $TRAVIS_OS_NAME == linux ]; then cd docs/doxygen; doxygen Doxyfile;  fi
+
+    - name: coverage
+      run: coveralls --exclude lib --exclude tests --exclude src/random --exclude src/codeCogs/ --exclude src/export/ --exclude src/gzstream/ --gcov-options '\-lp'

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -103,7 +103,7 @@ jobs:
          ./tests/test_binaryReproducible.sh
 
     - name: docs
-    - run:  if [ $TRAVIS_OS_NAME == linux ]; then cd docs/doxygen; doxygen Doxyfile;  fi
+      run:  if [ $TRAVIS_OS_NAME == linux ]; then cd docs/doxygen; doxygen Doxyfile;  fi
 
     - name: coverage
       run: coveralls --exclude lib --exclude tests --exclude src/random --exclude src/codeCogs/ --exclude src/export/ --exclude src/gzstream/ --gcov-options '\-lp'

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -124,5 +124,6 @@ jobs:
     - name: docs
       run:  if [ $TRAVIS_OS_NAME == linux ]; then cd docs/doxygen; doxygen Doxyfile;  fi
 
-    - name: coverage
-      run: coveralls --exclude lib --exclude tests --exclude src/random --exclude src/codeCogs/ --exclude src/export/ --exclude src/gzstream/ --gcov-options '\-lp'
+#  See: https://github.com/marketplace/actions/coveralls-github-action
+#    - name: coverage
+#      run: coveralls --exclude lib --exclude tests --exclude src/random --exclude src/codeCogs/ --exclude src/export/ --exclude src/gzstream/ --gcov-options '\-lp'

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ bin_PROGRAMS = dEploid dEploid_dbg
 man1_MANS = docs/_build/man/dEploid.1
 
 TESTS = unit_tests io_unit_tests
-check_PROGRAMS = unit_tests dEploid_dbg dEploid_prof io_unit_tests current_unit_tests
+check_PROGRAMS = unit_tests dEploid_dbg io_unit_tests current_unit_tests # dEploid_prof
 PROG = DEPLOID
 
 common_flags = -std=c++0x -Isrc/ -DDEPLOIDVERSION=\"${DEPLOIDVERSION}\" -DLASSOVERSION=\"${LASSOVERSION}\" -DCOMPILEDATE=\"${COMPILEDATE}\"

--- a/bootstrap
+++ b/bootstrap
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rm -r Makefile Makefile.in autom4te.cache config.* depcomp install-sh missing configure aclocal.m4 .deps INSTALL compile test-driver docs/doxygen/Makefile docs/doxygen/Makefile.in
+rm -rf Makefile Makefile.in autom4te.cache config.* depcomp install-sh missing configure aclocal.m4 .deps INSTALL compile test-driver docs/doxygen/Makefile docs/doxygen/Makefile.in
 
 root_dir=$PWD
 if [ ! -d "${root_dir}/src" ]; then

--- a/src/exceptions.hpp
+++ b/src/exceptions.hpp
@@ -39,7 +39,7 @@ struct ShouldNotBeCalled : std::exception{
   ShouldNotBeCalled() { }
   virtual ~ShouldNotBeCalled() throw() {}
   virtual const char* what() const noexcept {
-      return string("Should not reach here").c_str();
+      return "Should not reach here";
   }
 };
 
@@ -75,7 +75,7 @@ struct OutOfVectorSize : std::exception{
   OutOfVectorSize() { }
   virtual ~OutOfVectorSize() throw() {}
   virtual const char* what() const noexcept {
-      return string("Out of vector size!").c_str();
+      return "Out of vector size!";
   }
 };
 


### PR DESCRIPTION
This PR copies everything from travis over to github except:
- downloading the github tarball and compiling it 2 extra times
- coveralls

It runs the tests on both linux and mac, and tests both gcc and clang on linux.

Currently gcc-9 and gcc-10 are tested.

2c71a4b is a bugfix that could go into master separately -- I fixed it here because warnings from it were making the logs hard to read.

For coveralls, there is a github action at: https://github.com/marketplace/actions/coveralls-github-action
